### PR TITLE
FIX: issue #17

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -136,7 +136,7 @@ final class Module extends GenericModule
         $response = $this->api->read('items', $id);
         $content = $response->getContent();
         $resourceTemplate = $content->resourceTemplate();
-        $label = $resourceTemplate->label();
+        $label = $resourceTemplate ? $resourceTemplate->label() : null; // added null check to prevent error when resource template not set
         $useBackground = true; // later in config?
 
         if ( $label === 'LDS Dataset' ) {


### PR DESCRIPTION
The module tries to read the label of the resource template even when no template has been selected by the user. That causes error's when creating Items w/o selecting a template (e.g. when adding an item through the Collecting module or just leaving the dropdown as it is when creating a new Item. This fix sets the label to null when no template has been selected.