### PR TITLE
Fix: DataDumpJob EasyRdf parser exception

### DIFF
--- a/config/module.ini
+++ b/config/module.ini
@@ -1,5 +1,5 @@
 [info]
-version = "0.2"
+version = "0.2.1"
 omeka_version_constraint = "^4.0.0"
 name = "Linked Data Sets"
 description = "The Linked Data Sets module allows Omeka S users to create dataset descriptions in a data catalog with multiple distributions. When Itemsets are selected and an RDF format is chosen as distribution, a data dump is created from it."

--- a/src/Application/Service/ItemSetCrawler.php
+++ b/src/Application/Service/ItemSetCrawler.php
@@ -151,6 +151,12 @@ final class ItemSetCrawler
         RdfNamespace::set('o', 'http://omeka.org/s/vocabs/o#');
         $graph->parse($jsonLdString, "jsonld", $uri);
 
+        // Remove extracted_text literals (from module "Extract Text"): they may contain raw newline characters
+        // which are invalid inside N-Triples string literals and cause parse failures in the DataDumpJob.
+        foreach ($graph->resources() as $resource) {
+            $resource->delete('http://omeka.org/s/vocabs/o-module-extracttext#extracted_text');
+        }
+
         return $graph->serialise("nt");
     }
 


### PR DESCRIPTION
This change removes extracted_text literals (from module "Extract Text") from the json-LD, before converting it to Ntriples. 
The extracted_text literals may contain raw newline characters which are invalid inside N-Triples string literals and cause parse failures in the DataDumpJob.

Fixes https://github.com/netwerk-digitaal-erfgoed/Omeka-S-Module-LinkedDataSets/issues/23